### PR TITLE
User propensity

### DIFF
--- a/src/canister/individual_user_template/can.did
+++ b/src/canister/individual_user_template/can.did
@@ -612,6 +612,7 @@ service : (IndividualUserTemplateInitArgs) -> {
       Result_15,
     ) query;
   get_user_caniser_cycle_balance : () -> (nat) query;
+  get_user_propensity : () -> (float64) query;
   get_user_utility_token_transaction_history_with_pagination : (
       nat64,
       nat64,
@@ -665,6 +666,7 @@ service : (IndividualUserTemplateInitArgs) -> {
   update_referrer_details : (UserCanisterDetails) -> (Result_25);
   update_session_type : (SessionType) -> (Result_25);
   update_success_history : (SuccessHistoryItemV1) -> (Result_25);
+  update_user_propensity : (float64) -> (Result_25);
   update_watch_history : (WatchHistoryItem) -> (Result_25);
   update_well_known_principal : (KnownPrincipalType, principal) -> ();
   write_key_value_pair : (nat64, text, text) -> (Result_5);

--- a/src/canister/individual_user_template/src/api/ml_ops/mod.rs
+++ b/src/canister/individual_user_template/src/api/ml_ops/mod.rs
@@ -2,3 +2,4 @@ pub mod get_history;
 pub mod ml_feed_cache;
 pub mod update_success_history;
 pub mod update_watch_history;
+pub mod user_propensity;

--- a/src/canister/individual_user_template/src/api/ml_ops/user_propensity.rs
+++ b/src/canister/individual_user_template/src/api/ml_ops/user_propensity.rs
@@ -1,0 +1,28 @@
+use crate::{
+    api::canister_management::update_last_access_time::update_last_canister_functionality_access_time,
+    data_model::CanisterData, CANISTER_DATA,
+};
+use ic_cdk_macros::{query, update};
+use shared_utils::common::utils::permissions::is_caller_controller_or_global_admin;
+
+#[update(guard = "is_caller_controller_or_global_admin")]
+fn update_user_propensity(user_propensity: f64) -> Result<String, String> {
+    update_last_canister_functionality_access_time();
+
+    let _ = CANISTER_DATA.with(|canister_data| {
+        let mut canister_data = canister_data.borrow_mut();
+
+        canister_data.user_propensity = user_propensity;
+    });
+
+    Ok("Success".into())
+}
+
+#[query]
+fn get_user_propensity() -> f64 {
+    CANISTER_DATA.with(|canister_data| {
+        let canister_data = canister_data.borrow();
+
+        canister_data.user_propensity
+    })
+}

--- a/src/canister/individual_user_template/src/data_model/mod.rs
+++ b/src/canister/individual_user_template/src/data_model/mod.rs
@@ -91,6 +91,8 @@ pub struct CanisterData {
     // list of root token canisters
     #[serde(skip, default = "_default_token_list")]
     pub token_roots: ic_stable_structures::btreemap::BTreeMap<Principal, (), Memory>,
+    #[serde(default)]
+    pub user_propensity: f64,
 }
 
 pub fn _default_room_details(
@@ -128,7 +130,6 @@ pub fn _default_token_list() -> ic_stable_structures::btreemap::BTreeMap<Princip
     ic_stable_structures::btreemap::BTreeMap::init(get_token_list_memory())
 }
 
-
 pub fn _default_success_history_v1(
 ) -> ic_stable_structures::btreemap::BTreeMap<SuccessHistoryItemV1, (), Memory> {
     ic_stable_structures::btreemap::BTreeMap::init(get_success_history_memory())
@@ -163,7 +164,7 @@ impl Default for CanisterData {
             device_identities: Vec::new(),
             ml_feed_cache: Vec::new(),
             cdao_canisters: Vec::new(),
-            token_roots: _default_token_list()
+            token_roots: _default_token_list(),
         }
     }
 }

--- a/src/canister/individual_user_template/src/data_model/mod.rs
+++ b/src/canister/individual_user_template/src/data_model/mod.rs
@@ -165,6 +165,7 @@ impl Default for CanisterData {
             ml_feed_cache: Vec::new(),
             cdao_canisters: Vec::new(),
             token_roots: _default_token_list(),
+            user_propensity: 0.0,
         }
     }
 }


### PR DESCRIPTION

#### To check the status of the deployment

- check if the platform orchestrator performed the step to upgrade subnet canister with appropriate version: [Platform Orchestrator function](https://dashboard.internetcomputer.org/canister/74zq4-iqaaa-aaaam-ab53a-cai#get_subnet_last_upgrade_status)
- check the status of upgrade for individual canisters in subnet orchestrators and verify the version. Example for one of the subnet orchesrator: [Subnet Orchestrator function](https://dashboard.internetcomputer.org/canister/rimrc-piaaa-aaaao-aaljq-cai#get_index_details_last_upgrade_status)

To test the platform orchestrator, you can use the following command:

`dfx canister call --query 74zq4-iqaaa-aaaam-ab53a-cai get_subnet_last_upgrade_status --network=ic`
 the canister id (74zq4-iqaaa-aaaam-ab53a-cai) is taken from the canister_ids.json file